### PR TITLE
Add request and response to RateError with coverage

### DIFF
--- a/lib/fedex/request/rate.rb
+++ b/lib/fedex/request/rate.rb
@@ -34,7 +34,7 @@ module Fedex
                           rescue StandardError
                             $1
                           end
-          raise RateError, error_message
+          raise RateError.new(error_message, @response_xml, @request_xml)
         end
       end
 

--- a/lib/fedex/version.rb
+++ b/lib/fedex/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Fedex
-  VERSION = '3.17'
+  VERSION = '3.16.0'
   API_VERSION = '22'
   PICKUP_API_VERSION = '9'
   SERVICE_AVAILABILITY_API_VERSION = '5'

--- a/spec/lib/fedex/rate_spec.rb
+++ b/spec/lib/fedex/rate_spec.rb
@@ -226,6 +226,16 @@ module Fedex
           end
         end
       end
+
+      context 'when fedex responds with an error', :vcr do
+        it 'raises a rate error with messages' do
+          expect { rates }.to raise_error(Fedex::RateError) do |error|
+            expect(error.message).to eq 'Rating is temporarily unavailable, please try again later.  '
+            expect(error.api_request).to include('RateRequest')
+            expect(error.api_response).to include('RateReply')
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
VQ-13562, A continuation on VQ-13396. Add the response and request xmls to the RateError and add coverage