### PR TITLE
Change Rates API version for FICP Service VQ-14402

### DIFF
--- a/lib/fedex/request/rate.rb
+++ b/lib/fedex/request/rate.rb
@@ -76,7 +76,7 @@ module Fedex
       end
 
       def service
-        { id: 'crs', version: Fedex::API_VERSION }
+        { id: 'crs', version: Fedex::RATES_API_VERSION }
       end
 
       # Successful request

--- a/lib/fedex/version.rb
+++ b/lib/fedex/version.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 module Fedex
-  VERSION = '3.19'
+  VERSION = '3.20'
   API_VERSION = '26'
+  RATES_API_VERSION = '28'
   PICKUP_API_VERSION = '9'
   SERVICE_AVAILABILITY_API_VERSION = '5'
   UPLOAD_DOCUMENT_API_VERSION = '16'

--- a/spec/lib/fedex/rate_spec.rb
+++ b/spec/lib/fedex/rate_spec.rb
@@ -230,9 +230,9 @@ module Fedex
       context 'update WSDL major service number', :vcr do
         it_behaves_like 'successful rate request'
 
-        it 'should return version number 26' do
-          expect(rates.request_xml).to include '<Major>26</Major>'
-          expect(rates.response_xml["RateReply"]["Version"]).to include "Major" => "26"
+        it 'should return version number 28' do
+          expect(rates.request_xml).to include '<Major>28</Major>'
+          expect(rates.response_xml["RateReply"]["Version"]).to include "Major" => "28"
         end
       end
     end


### PR DESCRIPTION
Feedback from Fedex re showing [FICP service](https://veeqo-ltd.atlassian.net/browse/VQ-14402):

_According to the development team the version for shipping is indeed 26 but the rate request you need for the new services is V28_